### PR TITLE
Updated metadata column type to text, and made minor_version non null…

### DIFF
--- a/src/main/java/uk/co/onsdigital/discovery/model/DimensionalDataSet.java
+++ b/src/main/java/uk/co/onsdigital/discovery/model/DimensionalDataSet.java
@@ -64,12 +64,13 @@ public class DimensionalDataSet implements Serializable {
     @Column(name = "load_exception")
     private String loadException;
 
+    @Column(columnDefinition = "text")
     private String metadata;
 
     @Column(name = "major_version", nullable = false)
     private int majorVersion;
 
-    @Column(name = "minor_version")
+    @Column(name = "minor_version", nullable = false)
     private int minorVersion = 0;
 
     private String modified;


### PR DESCRIPTION
…able.

### What

Changes dimensionalDataSet.metadata column type to text to allow larger json values to be stored, made minor_version non nullable.

### How to review

You should be able to store json values with more than 255 characters, and the minor version field is now mandatory

### Who can review

@NeilMadden @CarlHembrough @YetAnotherMatt @fenallen
