### PR TITLE
Add hints to optimise relationship loading in API.

### DIFF
--- a/src/main/java/uk/co/onsdigital/discovery/model/DimensionValue.java
+++ b/src/main/java/uk/co/onsdigital/discovery/model/DimensionValue.java
@@ -1,7 +1,7 @@
 package uk.co.onsdigital.discovery.model;
 
-import org.eclipse.persistence.annotations.BatchFetch;
-import org.eclipse.persistence.annotations.BatchFetchType;
+import org.eclipse.persistence.annotations.JoinFetch;
+import org.eclipse.persistence.annotations.JoinFetchType;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -31,7 +31,7 @@ public class DimensionValue {
 
     @ManyToOne
     @JoinColumn(name = "hierarchy_entry_id")
-    @BatchFetch(BatchFetchType.JOIN)
+    @JoinFetch(JoinFetchType.OUTER)
     private HierarchyEntry hierarchyEntry;
 
     public DimensionValue() {

--- a/src/main/java/uk/co/onsdigital/discovery/model/DimensionValue.java
+++ b/src/main/java/uk/co/onsdigital/discovery/model/DimensionValue.java
@@ -3,13 +3,7 @@ package uk.co.onsdigital.discovery.model;
 import org.eclipse.persistence.annotations.JoinFetch;
 import org.eclipse.persistence.annotations.JoinFetchType;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
-import javax.persistence.UniqueConstraint;
+import javax.persistence.*;
 import java.util.UUID;
 
 @Entity

--- a/src/main/java/uk/co/onsdigital/discovery/model/DimensionValue.java
+++ b/src/main/java/uk/co/onsdigital/discovery/model/DimensionValue.java
@@ -1,14 +1,20 @@
 package uk.co.onsdigital.discovery.model;
 
-import javax.persistence.*;
-import java.io.Serializable;
+import org.eclipse.persistence.annotations.BatchFetch;
+import org.eclipse.persistence.annotations.BatchFetchType;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import java.util.UUID;
 
 @Entity
 @Table(name = "dimension_value", uniqueConstraints = @UniqueConstraint(columnNames={"dimensional_data_set_id", "name", "value"}))
 public class DimensionValue {
-
-    private static final long serialVersionUID = 1L;
 
     @Id
     @Column(columnDefinition = "uuid")
@@ -17,14 +23,15 @@ public class DimensionValue {
     @Column(name = "dimensional_data_set_id", columnDefinition = "uuid", nullable = false)
     private UUID dimensionalDataSetId;
 
-    @Column(nullable = false)
+    @Column(name = "name", nullable = false)
     private String name;
 
-    @Column(nullable = false)
+    @Column(name = "value", nullable = false)
     private String value;
 
     @ManyToOne
     @JoinColumn(name = "hierarchy_entry_id")
+    @BatchFetch(BatchFetchType.JOIN)
     private HierarchyEntry hierarchyEntry;
 
     public DimensionValue() {
@@ -35,6 +42,10 @@ public class DimensionValue {
         this.dimensionalDataSetId = dimensionalDataSetId;
         this.name = name;
         this.value = value;
+    }
+
+    public UUID getId() {
+        return id;
     }
 
     public HierarchyEntry getHierarchyEntry() {

--- a/src/main/java/uk/co/onsdigital/discovery/model/HierarchyEntry.java
+++ b/src/main/java/uk/co/onsdigital/discovery/model/HierarchyEntry.java
@@ -1,16 +1,16 @@
 package uk.co.onsdigital.discovery.model;
 
+import org.eclipse.persistence.annotations.JoinFetch;
+import org.eclipse.persistence.annotations.JoinFetchType;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
-import javax.persistence.IdClass;
 import javax.persistence.JoinColumn;
-import javax.persistence.JoinColumns;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
-import java.io.Serializable;
 import java.util.List;
 import java.util.UUID;
 
@@ -37,6 +37,7 @@ public class HierarchyEntry {
 
     @ManyToOne
     @JoinColumn(name = "hierarchy_level_type_id")
+    @JoinFetch(JoinFetchType.OUTER)
     private HierarchyLevelType levelType;
 
     @ManyToOne
@@ -46,6 +47,7 @@ public class HierarchyEntry {
     // bi-directional many-to-one relationship defining the trees structure. This is the owner side.
     @ManyToOne
     @JoinColumn(name = "parent", referencedColumnName = "id")
+    @JoinFetch(JoinFetchType.OUTER)
     private HierarchyEntry parent;
 
     // bi-directional one-to-many relationship defining the hierarchy. Owned by the children.

--- a/src/main/java/uk/co/onsdigital/discovery/model/HierarchyEntry.java
+++ b/src/main/java/uk/co/onsdigital/discovery/model/HierarchyEntry.java
@@ -3,14 +3,7 @@ package uk.co.onsdigital.discovery.model;
 import org.eclipse.persistence.annotations.JoinFetch;
 import org.eclipse.persistence.annotations.JoinFetchType;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
-import javax.persistence.UniqueConstraint;
+import javax.persistence.*;
 import java.util.List;
 import java.util.UUID;
 


### PR DESCRIPTION
### What

Added some explicit column names to workaround EclipseLink stupidity. Added some JoinFetch hint annotations to avoid N+1 queries when loading dimension data in the API. Before these changes loading the values for a dimension would load all the `dimension_value` entries in a single query, but then perform N additional queries for the linked `hierarchy_entry` for each one. After the changes it loads both at once using a `LEFT OUTER JOIN`:

```sql
SELECT t1.ID, t1.dimensional_data_set_id, t1.name, t1.value, t1.hierarchy_entry_id, t0.ID, t0.CODE, t0.display_order, t0.NAME, t0.hierarchy_id, t0.hierarchy_level_type_id, t0.parent FROM dimension_value t1 LEFT OUTER JOIN hierarchy_entry t0 ON (t0.ID = t1.hierarchy_entry_id) WHERE ((t1.name = ?) AND (t1.dimensional_data_set_id = ?))
```

### How to review

Eyeball.

### Who can review

Anyone but me.