### PR TITLE
Grant appropriate permissions to database roles.

### DIFF
--- a/src/main/resources/db/migration/V01_010__roles_and_permissions.sql
+++ b/src/main/resources/db/migration/V01_010__roles_and_permissions.sql
@@ -1,0 +1,11 @@
+-- Job Creator API user. Needs CRUD permissions on its own job status tables, minimal SELECT permissions otherwise.
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE job, file_status, job_file_status TO job_creator;
+GRANT SELECT ON TABLE dimensional_data_set TO job_creator; -- Needed to lookup S3 URL
+
+-- Metadata API user. Needs read-only permissions on most of the schema.
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO dd_api;
+REVOKE ALL ON TABLE job, file_status, job_file_status FROM dd_api;
+
+-- Ensure data_discovery has CRUD permissions on all non-job-related tables.
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO data_discovery;
+REVOKE ALL ON TABLE job, file_status, job_file_status FROM data_discovery;


### PR DESCRIPTION
### What

Adds a script to grant permissions to the three database roles used by the db loader, metadata API and job creator API. The roles themselves are created by the DB Loader (PR coming).

### How to review

Check permissions are appropriate for the roles.

### Who can review

Anyone but me.