### PR TITLE
Revert owner of job tables to data_discovery user.

### DIFF
--- a/src/main/resources/db/migration/V01_013__roles_and_permissions.sql
+++ b/src/main/resources/db/migration/V01_013__roles_and_permissions.sql
@@ -1,9 +1,6 @@
 -- Job Creator API user. Needs CRUD permissions on its own job status tables, minimal SELECT permissions otherwise.
 GRANT ALL PRIVILEGES ON TABLE job, file_status, job_file_status TO job_creator;
 GRANT SELECT ON TABLE dimensional_data_set TO job_creator; -- Needed to lookup S3 URL
-ALTER TABLE job owner TO job_creator;
-ALTER TABLE job_file_status owner TO job_creator;
-ALTER TABLE file_status owner TO job_creator;
 
 -- Metadata API user. Needs read-only permissions on most of the schema.
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO dd_api;
@@ -11,4 +8,3 @@ REVOKE ALL ON TABLE job, file_status, job_file_status FROM dd_api;
 
 -- Ensure data_discovery has CRUD permissions on all non-job-related tables.
 GRANT ALL PRIVILEGES ON SCHEMA public TO data_discovery;
-REVOKE ALL ON TABLE job, file_status, job_file_status FROM data_discovery;


### PR DESCRIPTION
### What

Changing the ownership of the job tables is causing errors. This reverts to using data_discovery and granting full permissions to the owner.

### How to review

Eyeball.

### Who can review

Anyone but me.