### PR TITLE
Removed observationTypeMarking, changed observationTypeValue to string

### DIFF
--- a/src/main/java/uk/co/onsdigital/discovery/model/DataPoint.java
+++ b/src/main/java/uk/co/onsdigital/discovery/model/DataPoint.java
@@ -16,14 +16,11 @@ public class DataPoint {
     @Column(columnDefinition = "numeric")
     private BigDecimal observation;
 
-    @Column(name = "observation_type_value", columnDefinition = "numeric")
-    private BigDecimal observationTypeValue;
+    @Column(name = "observation_type_value")
+    private String observationTypeValue;
 
     @Column(name = "data_marking")
     private String dataMarking;
-
-    @Column(name = "observation_type_marking")
-    private String observationTypeMarking;
 
     @ManyToMany
     @JoinTable(
@@ -50,11 +47,11 @@ public class DataPoint {
         this.observation = observation;
     }
 
-    public BigDecimal getObservationTypeValue() {
+    public String getObservationTypeValue() {
         return observationTypeValue;
     }
 
-    public void setObservationTypeValue(BigDecimal observationTypeValue) {
+    public void setObservationTypeValue(String observationTypeValue) {
         this.observationTypeValue = observationTypeValue;
     }
 
@@ -72,13 +69,5 @@ public class DataPoint {
 
     public void setDimensionValues(List<DimensionValue> dimensionValues) {
         this.dimensionValues = dimensionValues;
-    }
-
-    public String getObservationTypeMarking() {
-        return observationTypeMarking;
-    }
-
-    public void setObservationTypeMarking(String observationTypeMarking) {
-        this.observationTypeMarking = observationTypeMarking;
     }
 }

--- a/src/main/resources/db/migration/V01_025__add_observation_type_marking.sql
+++ b/src/main/resources/db/migration/V01_025__add_observation_type_marking.sql
@@ -1,1 +1,0 @@
-ALTER TABLE datapoint ADD COLUMN observation_type_marking varchar(255);

--- a/src/main/resources/db/migration/V01_025__observation_type_value_string.sql
+++ b/src/main/resources/db/migration/V01_025__observation_type_value_string.sql
@@ -1,0 +1,1 @@
+ALTER TABLE datapoint ALTER COLUMN observation_type_value TYPE varchar(255);


### PR DESCRIPTION
### What

Removed observationTypeMarking, changed observationTypeValue to string. As scrippt 1.25 hasn't been run anywhere yet, we can change the script rather than creating a new one.

### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.
