### PR TITLE
Use correct relationship type to avoid constraint violations with Hibernate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.co.onsdigital.discovery</groupId>
     <artifactId>dd-model</artifactId>
-    <version>1.0.34</version>
+    <version>1.0.35</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/main/java/uk/co/onsdigital/discovery/model/Job.java
+++ b/src/main/java/uk/co/onsdigital/discovery/model/Job.java
@@ -30,7 +30,7 @@ public class Job {
     @Enumerated(EnumType.STRING)
     private Status status = Status.PENDING;
 
-    @OneToMany(cascade = {CascadeType.ALL}, fetch = FetchType.EAGER)
+    @ManyToMany(cascade = {CascadeType.ALL}, fetch = FetchType.EAGER)
     @JoinTable(name = "job_file")
     private List<File> files = new ArrayList<>();
 


### PR DESCRIPTION
Use correct relationship type to avoid constraint violations with Hibernate. Fixes error in the job creator tests.